### PR TITLE
Add local ntfy pub/sub example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
 # ntfy-pub-sub-service
-https://github.com/binwiederhier/ntfy/tree/main -- pub/sub
+
+This repository shows a minimal local setup of the [ntfy](https://github.com/binwiederhier/ntfy/tree/main) server and a small Python backend script that publishes a message to a topic. You can subscribe to the same topic from the official ntfy mobile app to verify push notifications.
+
+## Services
+
+The included `docker-compose.yml` defines two services that share the same Docker network:
+
+* **ntfy** – runs the notification server and exposes port `8080` on the host.
+* **backend** – a Python container with a script that sends one message to ntfy.
+
+## Prerequisites
+
+* Docker and Docker Compose installed locally.
+* A phone with the ntfy mobile app installed (available on Android and iOS).
+* The phone must be able to reach your computer on the local network (e.g. same Wi‑Fi).
+
+## Usage
+
+1. **Start the services**
+
+   ```bash
+   docker compose up -d
+   ```
+
+   This launches the ntfy server. The backend container only runs when invoked explicitly.
+
+2. **Subscribe from the mobile app**
+
+   Open the ntfy app on your phone and add a new subscription:
+
+   * Base URL: `http://<your-computer-ip>:8080`
+   * Topic: `test-topic`
+
+   You can find the computer's IP address with `ip addr` (Linux) or `ipconfig` (Windows). Use the address reachable from your phone's network.
+
+3. **Send a test notification**
+
+   Run the backend script inside its container:
+
+   ```bash
+   docker compose run --rm backend
+   ```
+
+   The script posts the message `"Hello from backend!"` to the `test-topic` topic. You should see the notification in the mobile app.
+
+   To send a different message or topic:
+
+   ```bash
+   docker compose run --rm \
+     -e NTFY_TOPIC=mytopic \
+     -e NTFY_MESSAGE="Custom text" \
+     -e NTFY_TITLE="Optional title" \
+     backend
+   ```
+
+4. **Stop the stack**
+
+   ```bash
+   docker compose down
+   ```
+
+## Notes
+
+* Notifications are sent via plain HTTP (`http://`). This setup is intended for local testing only.
+* The ntfy service stores messages in a Docker volume named `ntfy-cache`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+RUN pip install --no-cache-dir requests
+WORKDIR /app
+COPY push_notification.py .
+ENTRYPOINT ["python", "push_notification.py"]

--- a/backend/push_notification.py
+++ b/backend/push_notification.py
@@ -1,0 +1,12 @@
+import os
+import requests
+
+topic = os.environ.get("NTFY_TOPIC", "test-topic")
+server = os.environ.get("NTFY_SERVER", "http://ntfy:80")
+title = os.environ.get("NTFY_TITLE", "Backend test")
+message = os.environ.get("NTFY_MESSAGE", "Hello from backend!")
+
+response = requests.post(f"{server}/{topic}", data=message.encode("utf-8"),
+                          headers={"Title": title})
+response.raise_for_status()
+print(f"Sent {message!r} to {topic} with status {response.status_code}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  ntfy:
+    image: binwiederhier/ntfy
+    ports:
+      - "8080:80"
+    volumes:
+      - ntfy-cache:/var/cache/ntfy
+    command: serve
+
+  backend:
+    build: ./backend
+    depends_on:
+      - ntfy
+
+volumes:
+  ntfy-cache:


### PR DESCRIPTION
## Summary
- add docker-compose with ntfy server and Python backend
- document local pub/sub scenario and usage steps
- provide sample backend script to publish to ntfy

## Testing
- `python -m py_compile backend/push_notification.py`
- `docker-compose config`